### PR TITLE
feat(diff): staged diff reader

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+pub struct Diff {
+    pub raw: String,
+    pub files_changed: Vec<String>,
+    pub is_empty: bool,
+}
+
+pub fn get_staged_diff() -> Result<Diff, String> {
+    let output = Command::new("git")
+        .args(["diff", "--cached", "--stat"])
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    let stat = String::from_utf8_lossy(&output.stdout).to_string();
+
+    let full_output = Command::new("git")
+        .args(["diff", "--cached"])
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    let raw = String::from_utf8_lossy(&full_output.stdout).to_string();
+
+    let files_changed: Vec<String> = stat
+        .lines()
+        .filter(|line| line.contains('|'))
+        .map(|line| line.split('|').next().unwrap_or("").trim().to_string())
+        .collect();
+
+    let is_empty = raw.trim().is_empty();
+
+    Ok(Diff {
+        raw,
+        files_changed,
+        is_empty,
+    })
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
+mod diff;
+
 use clap::{Parser, Subcommand};
 
-/// kommit — AI-powered git commit messages, fully local
 #[derive(Parser)]
-#[command(name = "kommit", version, about, long_about = None)]
+#[command(name = "kommit", version, about = "AI-powered git commit messages, fully local and offline")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -24,7 +25,21 @@ fn main() {
             println!("kommit: setting up in this repo...");
         }
         Commands::Generate => {
-            println!("kommit: generating commit message...");
+            match diff::get_staged_diff() {
+                Ok(d) if d.is_empty => {
+                    println!("Nothing staged. Run `git add` first.");
+                }
+                Ok(d) => {
+                    println!("Found {} changed file(s):", d.files_changed.len());
+                    for file in &d.files_changed {
+                        println!("  - {}", file);
+                    }
+                    println!("\nDiff preview ({} chars)", d.raw.len());
+                }
+                Err(e) => {
+                    eprintln!("Error reading diff: {}", e);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## What this does
Adds diff.rs module that reads the actual git staging area.

## How it works
- Runs `git diff --cached --stat` to get changed file list
- Runs `git diff --cached` to get full diff content
- Returns a typed Diff struct with raw content + parsed filenames

## Testing
Staged src/diff.rs and src/main.rs, ran `kommit generate`:
Found 2 changed file(s):
  - src/diff.rs
  - src/main.rs
  Diff preview (2520 chars)

## Next
This feeds into the model layer — diff.rs output goes to the LLM.