### PR TITLE
feat(model): prompt builder and generate stub

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod diff;
+mod model;
 
 use clap::{Parser, Subcommand};
 
@@ -30,11 +31,15 @@ fn main() {
                     println!("Nothing staged. Run `git add` first.");
                 }
                 Ok(d) => {
-                    println!("Found {} changed file(s):", d.files_changed.len());
-                    for file in &d.files_changed {
-                        println!("  - {}", file);
-                    }
-                    println!("\nDiff preview ({} chars)", d.raw.len());
+                    let req = model::GenerateRequest {
+                        diff: d.raw,
+                        files_changed: d.files_changed,
+                        style_hint: None,
+                    };
+                    let response = model::generate_stub(&req);
+                    println!("\nSuggested commit message:");
+                    println!("\n  {}\n", response.message);
+                    println!("Accept? [y/n/e to edit]: ");
                 }
                 Err(e) => {
                     eprintln!("Error reading diff: {}", e);

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,0 +1,75 @@
+pub struct GenerateRequest {
+    pub diff: String,
+    pub files_changed: Vec<String>,
+    pub style_hint: Option<String>,
+}
+
+pub struct GenerateResponse {
+    pub message: String,
+    pub confidence: f32,
+}
+
+pub fn build_prompt(req: &GenerateRequest) -> String {
+    let files_summary = if req.files_changed.is_empty() {
+        "unknown files".to_string()
+    } else {
+        req.files_changed.join(", ")
+    };
+
+    let diff_preview = if req.diff.len() > 3000 {
+        format!("{}... [truncated]", &req.diff[..3000])
+    } else {
+        req.diff.clone()
+    };
+
+    let style = req
+        .style_hint
+        .as_deref()
+        .unwrap_or("conventional commits format like: feat(scope): description");
+
+    format!(
+        r#"You are a git commit message generator. 
+Generate ONE commit message for the following staged changes.
+Use this style: {style}
+Rules:
+- Start with a type: feat, fix, chore, docs, refactor, test
+- Keep it under 72 characters
+- Be specific, not generic
+- No period at the end
+
+Changed files: {files_summary}
+
+Diff:
+{diff_preview}
+
+Commit message:"#
+    )
+}
+
+pub fn generate_stub(req: &GenerateRequest) -> GenerateResponse {
+    let prompt = build_prompt(req);
+
+    println!("[debug] Prompt built ({} chars)", prompt.len());
+    println!("[debug] Model inference will go here");
+
+    let file_hint = req
+        .files_changed
+        .first()
+        .map(|f| {
+            if f.contains("test") { "test" }
+            else if f.contains("readme") || f.contains("README") { "docs" }
+            else { "feat" }
+        })
+        .unwrap_or("chore");
+
+    let scope = req
+        .files_changed
+        .first()
+        .and_then(|f| f.split('/').nth(1))
+        .unwrap_or("core");
+
+    GenerateResponse {
+        message: format!("{}({}): update implementation", file_hint, scope),
+        confidence: 0.0,
+    }
+}


### PR DESCRIPTION
## What this does
Adds model.rs with the full generation pipeline (stubbed inference).

## Components
- `GenerateRequest` / `GenerateResponse` typed structs
- `build_prompt()` formats diff into a quality LLM prompt
- `generate_stub()` simulates model output, full model next

## Prompt features
- Truncates diffs over 3000 chars (context window safety)
- Injects style hint for personal commit style learning
- Conventional commits format enforced in system prompt

## Testing
Ran `kommit generate` with staged files:
[debug] Prompt built (3406 chars)
Suggested commit message: feat(main.rs): update implementation

## Next PR
Replace generate_stub with real llama.cpp inference