### PR TITLE
feat(style): git history style learner

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod diff;
 mod model;
+mod style;
 
 use clap::{Parser, Subcommand};
 
@@ -29,24 +30,34 @@ fn main() {
         Commands::Init => {
             println!("kommit: setting up in this repo...");
         }
-        Commands::Generate => match diff::get_staged_diff() {
-            Ok(d) if d.is_empty => {
-                println!("Nothing staged. Run `git add` first.");
+        Commands::Generate => {
+            let profile = style::learn_from_git_log();
+            let style_hint = style::build_style_hint(&profile);
+
+            println!("Learning from your last commits...");
+            println!("  Preferred type : {}", profile.preferred_type);
+            println!("  Uses scope     : {}", profile.uses_scope);
+            println!("  Avg length     : {} chars", profile.avg_length);
+
+            match diff::get_staged_diff() {
+                Ok(d) if d.is_empty => {
+                    println!("Nothing staged. Run `git add` first.");
+                }
+                Ok(d) => {
+                    let req = model::GenerateRequest {
+                        diff: d.raw,
+                        files_changed: d.files_changed,
+                        style_hint: Some(style_hint),
+                    };
+                    let response = model::generate_stub(&req);
+                    println!("\nSuggested commit message:");
+                    println!("\n  {}\n", response.message);
+                    println!("Accept? [y/n/e to edit]: ");
+                }
+                Err(e) => {
+                    eprintln!("Error reading diff: {}", e);
+                }
             }
-            Ok(d) => {
-                let req = model::GenerateRequest {
-                    diff: d.raw,
-                    files_changed: d.files_changed,
-                    style_hint: None,
-                };
-                let response = model::generate_stub(&req);
-                println!("\nSuggested commit message:");
-                println!("\n  {}\n", response.message);
-                println!("Accept? [y/n/e to edit]: ");
-            }
-            Err(e) => {
-                eprintln!("Error reading diff: {}", e);
-            }
-        },
+        }
     }
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,74 @@
+use std::process::Command;
+
+pub struct StyleProfile {
+    pub preferred_type: String,
+    pub avg_length: usize,
+    pub uses_scope: bool,
+    #[allow(dead_code)]
+    pub sample_messages: Vec<String>,
+}
+
+impl Default for StyleProfile {
+    fn default() -> Self {
+        StyleProfile {
+            preferred_type: "feat".to_string(),
+            avg_length: 50,
+            uses_scope: false,
+            sample_messages: vec![],
+        }
+    }
+}
+
+pub fn learn_from_git_log() -> StyleProfile {
+    let output = Command::new("git")
+        .args(["log", "--oneline", "-50", "--pretty=format:%s"])
+        .output();
+
+    let Ok(output) = output else {
+        return StyleProfile::default();
+    };
+
+    let log = String::from_utf8_lossy(&output.stdout);
+    let messages: Vec<&str> = log.lines().collect();
+
+    if messages.is_empty() {
+        return StyleProfile::default();
+    }
+
+    let uses_scope = messages.iter().any(|m| m.contains('(') && m.contains(')'));
+
+    let avg_length = messages
+        .iter()
+        .map(|m| m.len())
+        .sum::<usize>()
+        .checked_div(messages.len())
+        .unwrap_or(50);
+
+    let preferred_type = ["feat", "fix", "chore", "refactor", "docs", "test"]
+        .iter()
+        .max_by_key(|t| messages.iter().filter(|m| m.starts_with(*t)).count())
+        .unwrap_or(&"feat")
+        .to_string();
+
+    let sample_messages = messages.iter().take(5).map(|s| s.to_string()).collect();
+
+    StyleProfile {
+        preferred_type,
+        avg_length,
+        uses_scope,
+        sample_messages,
+    }
+}
+
+pub fn build_style_hint(profile: &StyleProfile) -> String {
+    let scope_note = if profile.uses_scope {
+        "include a scope in parentheses like feat(scope):"
+    } else {
+        "no scope needed, just type: description"
+    };
+
+    format!(
+        "conventional commits, prefer '{}' type, keep under {} chars, {}",
+        profile.preferred_type, profile.avg_length, scope_note
+    )
+}


### PR DESCRIPTION
## What this does
Adds style.rs that analyzes your last 50 commits to learn
your personal commit style.

## What it learns
- Preferred commit type (feat/fix/chore etc)
- Whether you use scopes like feat(scope):
- Average message length

## Output on this repo
Preferred type : feat
Uses scope     : true
Avg length     : 51 chars

## Next
This style hint feeds directly into the model prompt,
so generated messages match your personal style.