### PR TITLE
feat(hook): install prepare-commit-msg git hook

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,0 +1,68 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+pub enum HookStatus {
+    Installed,
+    AlreadyInstalled,
+    NotAGitRepo,
+    Failed(String),
+}
+
+fn find_git_root() -> Option<PathBuf> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+    Some(PathBuf::from(path))
+}
+
+pub fn install_hook() -> HookStatus {
+    let Some(git_root) = find_git_root() else {
+        return HookStatus::NotAGitRepo;
+    };
+
+    let hook_path = git_root
+        .join(".git")
+        .join("hooks")
+        .join("prepare-commit-msg");
+
+    if hook_path.exists() {
+        let existing = fs::read_to_string(&hook_path).unwrap_or_default();
+        if existing.contains("kommit") {
+            return HookStatus::AlreadyInstalled;
+        }
+    }
+
+    let hook_script = "#!/bin/sh\nkommit generate --hook \"$1\"\n";
+
+    match fs::write(&hook_path, hook_script) {
+        Ok(_) => {
+            set_executable(&hook_path);
+            HookStatus::Installed
+        }
+        Err(e) => HookStatus::Failed(e.to_string()),
+    }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(mut perms) = fs::metadata(path).map(|m| m.permissions()) {
+        perms.set_mode(0o755);
+        let _ = fs::set_permissions(path, perms);
+    }
+}
+
+#[cfg(windows)]
+fn set_executable(_path: &PathBuf) {
+    // Windows doesn't use Unix permissions
+    // Git for Windows handles executable bits separately
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod diff;
+mod hook;
 mod model;
 mod style;
 
@@ -28,7 +29,23 @@ fn main() {
 
     match cli.command {
         Commands::Init => {
-            println!("kommit: setting up in this repo...");
+            println!("Setting up kommit...");
+            match hook::install_hook() {
+                hook::HookStatus::Installed => {
+                    println!("Hook installed. kommit will now suggest messages on every commit.");
+                }
+                hook::HookStatus::AlreadyInstalled => {
+                    println!("Hook already installed. You're good to go.");
+                }
+                hook::HookStatus::NotAGitRepo => {
+                    eprintln!("Error: not inside a git repository.");
+                    std::process::exit(1);
+                }
+                hook::HookStatus::Failed(e) => {
+                    eprintln!("Failed to install hook: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         Commands::Generate => {
             let profile = style::learn_from_git_log();


### PR DESCRIPTION
## What this does
Adds hook.rs that writes the prepare-commit-msg hook
into any git repo's .git/hooks/ folder.

## How it works
- Finds git root via `git rev-parse --show-toplevel`
- Writes a 2-line shell script that calls `kommit generate`
- Skips if kommit hook already exists
- Cross-platform: chmod 755 on Unix, no-op on Windows

## Known issue fixed next PR
Hook fires before binary is in PATH during development.
Next PR adds a PATH check before installing.

## Testing
cargo run -- init
→ "Hook installed. kommit will now suggest messages on every commit."