### PR TITLE
fix(hook): guard hook install behind PATH check

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -6,6 +6,7 @@ pub enum HookStatus {
     Installed,
     AlreadyInstalled,
     NotAGitRepo,
+    KommitNotInPath,
     Failed(String),
 }
 
@@ -24,10 +25,22 @@ fn find_git_root() -> Option<PathBuf> {
     Some(PathBuf::from(path))
 }
 
+fn is_kommit_in_path() -> bool {
+    Command::new("kommit")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
 pub fn install_hook() -> HookStatus {
     let Some(git_root) = find_git_root() else {
         return HookStatus::NotAGitRepo;
     };
+
+    if !is_kommit_in_path() {
+        return HookStatus::KommitNotInPath;
+    }
 
     let hook_path = git_root
         .join(".git")
@@ -62,7 +75,4 @@ fn set_executable(path: &PathBuf) {
 }
 
 #[cfg(windows)]
-fn set_executable(_path: &PathBuf) {
-    // Windows doesn't use Unix permissions
-    // Git for Windows handles executable bits separately
-}
+fn set_executable(_path: &PathBuf) {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,12 @@ fn main() {
                     eprintln!("Error: not inside a git repository.");
                     std::process::exit(1);
                 }
+                hook::HookStatus::KommitNotInPath => {
+                    eprintln!("Error: kommit is not in your PATH.");
+                    eprintln!("Add the binary to your PATH first, then run `kommit init` again.");
+                    eprintln!("See README for install instructions.");
+                    std::process::exit(1);
+                }
                 hook::HookStatus::Failed(e) => {
                     eprintln!("Failed to install hook: {}", e);
                     std::process::exit(1);


### PR DESCRIPTION
## Problem
If kommit isn't in PATH and the hook is installed,
every git commit breaks with "kommit: command not found".
We hit this ourselves during development.

## Fix
Added is_kommit_in_path() check before writing the hook.
If kommit isn't found, we exit with a clear error message
telling the user to add it to PATH first.

## New HookStatus variant
KommitNotInPath — gives a clear actionable error message.