### PR TITLE
feat(interactive): user prompt with timing

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -1,0 +1,74 @@
+use std::io::{self, BufRead, Write};
+
+pub enum UserChoice {
+    Accept,
+    Edit(String),
+    Reject,
+    Regenerate,
+}
+
+pub fn prompt_user(suggested: &str) -> UserChoice {
+    loop {
+        println!();
+        println!("  Suggested message:");
+        println!();
+        println!("    {}", suggested);
+        println!();
+        println!("  y  accept    e  edit    r  regenerate    n  cancel");
+        println!();
+        print!("  Your choice: ");
+
+        io::stdout().flush().unwrap();
+
+        let stdin = io::stdin();
+        let line = stdin.lock().lines().next();
+
+        let input = match line {
+            Some(Ok(l)) => l.trim().to_lowercase(),
+            _ => continue,
+        };
+
+        match input.as_str() {
+            "y" | "yes" | "" => return UserChoice::Accept,
+            "n" | "no" => return UserChoice::Reject,
+            "r" => return UserChoice::Regenerate,
+            "e" | "edit" => {
+                print!("  New message: ");
+                io::stdout().flush().unwrap();
+
+                let edited = stdin
+                    .lock()
+                    .lines()
+                    .next()
+                    .and_then(|l| l.ok())
+                    .unwrap_or_default();
+
+                let trimmed = edited.trim().to_string();
+                if trimmed.is_empty() {
+                    println!("  Empty message, try again.");
+                    continue;
+                }
+                return UserChoice::Edit(trimmed);
+            }
+            _ => {
+                println!("  Please enter y, e, r, or n.");
+                continue;
+            }
+        }
+    }
+}
+
+pub fn commit_with_message(message: &str) -> Result<(), String> {
+    let output = std::process::Command::new("git")
+        .args(["commit", "-m", message])
+        .output()
+        .map_err(|e| format!("Failed to run git commit: {}", e))?;
+
+    if output.status.success() {
+        println!("\nCommitted: {}", message);
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("git commit failed: {}", stderr))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod diff;
 mod hook;
+mod interactive;
 mod model;
 mod style;
 
@@ -44,7 +45,6 @@ fn main() {
                 hook::HookStatus::KommitNotInPath => {
                     eprintln!("Error: kommit is not in your PATH.");
                     eprintln!("Add the binary to your PATH first, then run `kommit init` again.");
-                    eprintln!("See README for install instructions.");
                     std::process::exit(1);
                 }
                 hook::HookStatus::Failed(e) => {
@@ -60,22 +60,65 @@ fn main() {
             println!("Learning from your last commits...");
             println!("  Preferred type : {}", profile.preferred_type);
             println!("  Uses scope     : {}", profile.uses_scope);
-            println!("  Avg length     : {} chars", profile.avg_length);
+            println!("  Avg length     : {} chars\n", profile.avg_length);
 
             match diff::get_staged_diff() {
                 Ok(d) if d.is_empty => {
                     println!("Nothing staged. Run `git add` first.");
                 }
                 Ok(d) => {
+                    println!("Generating commit message...\n");
+
+                    let start = std::time::Instant::now();
+
                     let req = model::GenerateRequest {
-                        diff: d.raw,
-                        files_changed: d.files_changed,
-                        style_hint: Some(style_hint),
+                        diff: d.raw.clone(),
+                        files_changed: d.files_changed.clone(),
+                        style_hint: Some(style_hint.clone()),
                     };
-                    let response = model::generate_stub(&req);
-                    println!("\nSuggested commit message:");
-                    println!("\n  {}\n", response.message);
-                    println!("Accept? [y/n/e to edit]: ");
+
+                    let mut response = model::generate_stub(&req);
+                    let elapsed = start.elapsed();
+                    println!("  Generated in {:.1}s\n", elapsed.as_secs_f32());
+
+                    loop {
+                        match interactive::prompt_user(&response.message) {
+                            interactive::UserChoice::Accept => {
+                                match interactive::commit_with_message(&response.message) {
+                                    Ok(_) => break,
+                                    Err(e) => {
+                                        eprintln!("Error: {}", e);
+                                        break;
+                                    }
+                                }
+                            }
+                            interactive::UserChoice::Edit(new_msg) => {
+                                match interactive::commit_with_message(&new_msg) {
+                                    Ok(_) => break,
+                                    Err(e) => {
+                                        eprintln!("Error: {}", e);
+                                        break;
+                                    }
+                                }
+                            }
+                            interactive::UserChoice::Reject => {
+                                println!("Cancelled. Nothing committed.");
+                                break;
+                            }
+                            interactive::UserChoice::Regenerate => {
+                                println!("Regenerating...\n");
+                                let regen_start = std::time::Instant::now();
+                                let new_req = model::GenerateRequest {
+                                    diff: d.raw.clone(),
+                                    files_changed: d.files_changed.clone(),
+                                    style_hint: Some(style_hint.clone()),
+                                };
+                                response = model::generate_stub(&new_req);
+                                let regen_elapsed = regen_start.elapsed();
+                                println!("  Generated in {:.1}s\n", regen_elapsed.as_secs_f32());
+                            }
+                        }
+                    }
                 }
                 Err(e) => {
                     eprintln!("Error reading diff: {}", e);


### PR DESCRIPTION
## What this does
Adds interactive prompt after message generation.

## Options
- y - accept and commit
- e - edit then commit  
- r - regenerate (calls model again)
- n - cancel

## UX
- Clean layout, no alignment issues on Windows
- Shows generation time after each suggestion
- Loop continues until valid choice

## Example output
  Generated in 1.9s

  Suggested message:
    feat(intro): Add interactive commit message feature

  y  accept    e  edit    r  regenerate    n  cancel

Closes #10