### PR TITLE
ci: cross-platform release binary workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-release:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: kommit.exe
+            asset_name: kommit-windows-x86_64.exe
+
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: kommit
+            asset_name: kommit-macos-x86_64
+
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: kommit
+            asset_name: kommit-linux-x86_64
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: target/${{ matrix.target }}/release/${{ matrix.binary }}
+          name: ${{ matrix.asset_name }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What this does
Adds release.yml that triggers on version tags.
Builds binaries for all three platforms simultaneously.

## Platforms
- Windows → kommit-windows-x86_64.exe
- Mac     → kommit-macos-x86_64
- Linux   → kommit-linux-x86_64

## How to trigger
git tag v0.3.0
git push origin v0.3.0

Binaries appear on the GitHub Release page automatically.