### PR TITLE
feat(diff): exclude junk files from model input

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -26,9 +26,9 @@ const JUNK_FILENAMES: &[&str] = &[
 
 fn is_junk_file(path: &str) -> bool {
     let lower = path.to_lowercase();
-    let filename = lower.split('/').last().unwrap_or(&lower);
+    let filename = lower.split('/').next_back().unwrap_or(&lower);
 
-    if JUNK_FILENAMES.iter().any(|j| filename == *j) {
+    if JUNK_FILENAMES.contains(&filename) {
         return true;
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,6 +4,39 @@ pub struct Diff {
     pub raw: String,
     pub files_changed: Vec<String>,
     pub is_empty: bool,
+    pub skipped_files: Vec<String>,
+}
+
+const JUNK_EXTENSIONS: &[&str] = &[
+    ".lock", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".woff", ".woff2", ".ttf", ".eot",
+    ".pdf", ".zip", ".tar", ".gz", ".exe", ".dll", ".so", ".dylib",
+];
+
+const JUNK_FILENAMES: &[&str] = &[
+    "package-lock.json",
+    "yarn.lock",
+    "pnpm-lock.yaml",
+    "Cargo.lock",
+    "Gemfile.lock",
+    "poetry.lock",
+    "composer.lock",
+    "packages.lock.json",
+    "pubspec.lock",
+];
+
+fn is_junk_file(path: &str) -> bool {
+    let lower = path.to_lowercase();
+    let filename = lower.split('/').last().unwrap_or(&lower);
+
+    if JUNK_FILENAMES.iter().any(|j| filename == *j) {
+        return true;
+    }
+
+    if JUNK_EXTENSIONS.iter().any(|ext| lower.ends_with(ext)) {
+        return true;
+    }
+
+    false
 }
 
 pub fn get_staged_diff() -> Result<Diff, String> {
@@ -14,24 +47,40 @@ pub fn get_staged_diff() -> Result<Diff, String> {
 
     let stat = String::from_utf8_lossy(&output.stdout).to_string();
 
-    let full_output = Command::new("git")
-        .args(["diff", "--cached"])
-        .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
-
-    let raw = String::from_utf8_lossy(&full_output.stdout).to_string();
-
-    let files_changed: Vec<String> = stat
+    let all_files: Vec<String> = stat
         .lines()
         .filter(|line| line.contains('|'))
         .map(|line| line.split('|').next().unwrap_or("").trim().to_string())
         .collect();
 
+    let (good_files, skipped_files): (Vec<String>, Vec<String>) =
+        all_files.into_iter().partition(|f| !is_junk_file(f));
+
+    if good_files.is_empty() && !skipped_files.is_empty() {
+        return Ok(Diff {
+            raw: String::new(),
+            files_changed: vec![],
+            is_empty: true,
+            skipped_files,
+        });
+    }
+
+    let mut diff_args = vec!["diff", "--cached", "--"];
+    let good_file_refs: Vec<&str> = good_files.iter().map(|s| s.as_str()).collect();
+    diff_args.extend_from_slice(&good_file_refs);
+
+    let full_output = Command::new("git")
+        .args(&diff_args)
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    let raw = String::from_utf8_lossy(&full_output.stdout).to_string();
     let is_empty = raw.trim().is_empty();
 
     Ok(Diff {
         raw,
-        files_changed,
+        files_changed: good_files,
         is_empty,
+        skipped_files,
     })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,6 +67,14 @@ fn main() {
                     println!("Nothing staged. Run `git add` first.");
                 }
                 Ok(d) => {
+                    if !d.skipped_files.is_empty() {
+                        println!(
+                            "  Skipped {} junk file(s): {}\n",
+                            d.skipped_files.len(),
+                            d.skipped_files.join(", ")
+                        );
+                    }
+
                     println!("Generating commit message...\n");
 
                     let start = std::time::Instant::now();


### PR DESCRIPTION
## What this does
Filters out files that should never reach the model
before building the diff sent for inference.

## Excluded files
Lock files: Cargo.lock, package-lock.json, yarn.lock,
pnpm-lock.yaml, poetry.lock, Gemfile.lock and others.

Binary/media: .png, .jpg, .gif, .svg, .ico, .pdf,
.zip, .exe, .dll, .so, .dylib, .woff, .ttf

## UX
Shows skipped files count in output so user knows
what was excluded.

## Why this matters
Lock files have thousands of generated lines that
confuse the model and waste context window.
Binary diffs are pure noise.

Partially closes #19
Partially closes #12