### PR TITLE
feat(config): configurable model and ollama settings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,64 @@
+use std::fs;
+use std::path::PathBuf;
+
+pub struct Config {
+    pub ollama_url: String,
+    pub model: String,
+    pub max_diff_chars: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            ollama_url: "http://localhost:11434".to_string(),
+            model: "qwen2.5-coder:1.5b".to_string(),
+            max_diff_chars: 3000,
+        }
+    }
+}
+
+fn config_path() -> PathBuf {
+    let home = std::env::var("USERPROFILE")
+        .or_else(|_| std::env::var("HOME"))
+        .unwrap_or_else(|_| ".".to_string());
+
+    PathBuf::from(home).join(".kommit").join("config.toml")
+}
+
+pub fn load() -> Config {
+    let path = config_path();
+
+    let content = match fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(_) => return Config::default(),
+    };
+
+    let mut config = Config::default();
+
+    for line in content.lines() {
+        let line = line.trim();
+        if line.starts_with('#') || line.is_empty() {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            let key = key.trim();
+            let value = value.trim().trim_matches('"');
+            match key {
+                "model" => config.model = value.to_string(),
+                "ollama_url" => config.ollama_url = value.to_string(),
+                "max_diff_chars" => {
+                    if let Ok(n) = value.parse() {
+                        config.max_diff_chars = n;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    config
+}
+
+pub fn show_path() -> String {
+    config_path().display().to_string()
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod diff;
 mod hook;
 mod interactive;
@@ -23,6 +24,8 @@ enum Commands {
     Init,
     /// Generate a commit message from staged changes
     Generate,
+    /// Show current config and config file location
+    Config,
 }
 
 fn main() {
@@ -132,6 +135,19 @@ fn main() {
                     eprintln!("Error reading diff: {}", e);
                 }
             }
+        }
+        Commands::Config => {
+            let config = config::load();
+            println!("Config file: {}", config::show_path());
+            println!();
+            println!("  model          = {}", config.model);
+            println!("  ollama_url     = {}", config.ollama_url);
+            println!("  max_diff_chars = {}", config.max_diff_chars);
+            println!();
+            println!("To customize, create the config file and add:");
+            println!("  model = \"llama3.2:3b\"");
+            println!("  ollama_url = \"http://localhost:11434\"");
+            println!("  max_diff_chars = 4000");
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -25,14 +25,16 @@ struct OllamaResponse {
 }
 
 pub fn build_prompt(req: &GenerateRequest) -> String {
+    let config = crate::config::load();
+
     let files_summary = if req.files_changed.is_empty() {
         "unknown files".to_string()
     } else {
         req.files_changed.join(", ")
     };
 
-    let diff_preview = if req.diff.len() > 3000 {
-        format!("{}... [truncated]", &req.diff[..3000])
+    let diff_preview = if req.diff.len() > config.max_diff_chars {
+        format!("{}... [truncated]", &req.diff[..config.max_diff_chars])
     } else {
         req.diff.clone()
     };
@@ -63,9 +65,10 @@ Commit message:"#
 }
 
 pub fn generate(req: &GenerateRequest) -> GenerateResponse {
+    let config = crate::config::load();
     let prompt = build_prompt(req);
 
-    match call_ollama(&prompt) {
+    match call_ollama(&prompt, &config.ollama_url, &config.model) {
         Ok(message) => GenerateResponse {
             message: message.trim().to_string(),
             confidence: 1.0,
@@ -73,6 +76,7 @@ pub fn generate(req: &GenerateRequest) -> GenerateResponse {
         Err(e) => {
             eprintln!("Model error: {}", e);
             eprintln!("Make sure ollama is running: ollama serve");
+            eprintln!("Config file: {}", crate::config::show_path());
             GenerateResponse {
                 message: "chore: update implementation".to_string(),
                 confidence: 0.0,
@@ -81,21 +85,23 @@ pub fn generate(req: &GenerateRequest) -> GenerateResponse {
     }
 }
 
-fn call_ollama(prompt: &str) -> Result<String, String> {
+fn call_ollama(prompt: &str, base_url: &str, model: &str) -> Result<String, String> {
     let client = reqwest::blocking::Client::new();
 
     let body = OllamaRequest {
-        model: "qwen2.5-coder:1.5b".to_string(),
+        model: model.to_string(),
         prompt: prompt.to_string(),
         stream: false,
     };
 
+    let url = format!("{}/api/generate", base_url);
+
     let response = client
-        .post("http://localhost:11434/api/generate")
+        .post(&url)
         .json(&body)
         .timeout(std::time::Duration::from_secs(30))
         .send()
-        .map_err(|e| format!("Failed to reach ollama: {}", e))?;
+        .map_err(|e| format!("Failed to reach ollama at {}: {}", base_url, e))?;
 
     let ollama_response: OllamaResponse = response
         .json()


### PR DESCRIPTION
## What this does
Adds ~/.kommit/config.toml for user configuration.
No setup required — defaults work out of the box.

## Configurable settings
- model — any ollama model name
- ollama_url — for remote ollama instances  
- max_diff_chars — context window limit

## New command
`kommit config` shows current settings and config file path.

## Example config
model = "llama3.2:3b"
ollama_url = "http://localhost:11434"
max_diff_chars = 4000

## Why this matters
Users can now switch models without recompiling.
Supports remote ollama setups.
Addresses community request for model flexibility.