### PR TITLE
feat(model): commit message body with reasoning

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -10,9 +10,26 @@ pub enum UserChoice {
 pub fn prompt_user(suggested: &str) -> UserChoice {
     loop {
         println!();
+
+        let parts: Vec<&str> = suggested.splitn(2, "\n\n").collect();
+        let subject = parts[0].trim();
+
         println!("  Suggested message:");
         println!();
-        println!("    {}", suggested);
+        println!("    {}", subject);
+
+        if parts.len() > 1 {
+            let body = parts[1].trim();
+            if !body.is_empty() {
+                println!();
+                println!("  Reasoning:");
+                println!();
+                for line in body.lines() {
+                    println!("    {}", line);
+                }
+            }
+        }
+
         println!();
         println!("  y  accept    e  edit    r  regenerate    n  cancel");
         println!();

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,12 @@ enum Commands {
     /// Set up kommit in the current git repo
     Init,
     /// Generate a commit message from staged changes
-    Generate,
+    #[command(arg_required_else_help = false)]
+    Generate {
+        /// Include reasoning body in commit message
+        #[arg(long, short)]
+        body: bool,
+    },
     /// Show current config and config file location
     Config,
 }
@@ -56,7 +61,7 @@ fn main() {
                 }
             }
         }
-        Commands::Generate => {
+        Commands::Generate { body } => {
             let profile = style::learn_from_git_log();
             let style_hint = style::build_style_hint(&profile);
 
@@ -78,7 +83,11 @@ fn main() {
                         );
                     }
 
-                    println!("Generating commit message...\n");
+                    if body {
+                        println!("Generating commit message with reasoning...\n");
+                    } else {
+                        println!("Generating commit message...\n");
+                    }
 
                     let start = std::time::Instant::now();
 
@@ -86,6 +95,7 @@ fn main() {
                         diff: d.raw.clone(),
                         files_changed: d.files_changed.clone(),
                         style_hint: Some(style_hint.clone()),
+                        include_body: body,
                     };
 
                     let mut response = model::generate_stub(&req);
@@ -93,9 +103,9 @@ fn main() {
                     println!("  Generated in {:.1}s\n", elapsed.as_secs_f32());
 
                     loop {
-                        match interactive::prompt_user(&response.message) {
+                        match interactive::prompt_user(&response.full_message()) {
                             interactive::UserChoice::Accept => {
-                                match interactive::commit_with_message(&response.message) {
+                                match interactive::commit_with_message(&response.full_message()) {
                                     Ok(_) => break,
                                     Err(e) => {
                                         eprintln!("Error: {}", e);
@@ -123,6 +133,7 @@ fn main() {
                                     diff: d.raw.clone(),
                                     files_changed: d.files_changed.clone(),
                                     style_hint: Some(style_hint.clone()),
+                                    include_body: body,
                                 };
                                 response = model::generate_stub(&new_req);
                                 let regen_elapsed = regen_start.elapsed();

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,12 +4,23 @@ pub struct GenerateRequest {
     pub diff: String,
     pub files_changed: Vec<String>,
     pub style_hint: Option<String>,
+    pub include_body: bool,
 }
 
 pub struct GenerateResponse {
     pub message: String,
+    pub body: Option<String>,
     #[allow(dead_code)]
     pub confidence: f32,
+}
+
+impl GenerateResponse {
+    pub fn full_message(&self) -> String {
+        match &self.body {
+            Some(b) if !b.is_empty() => format!("{}\n\n{}", self.message, b),
+            _ => self.message.clone(),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -44,8 +55,35 @@ pub fn build_prompt(req: &GenerateRequest) -> String {
         .as_deref()
         .unwrap_or("conventional commits format like: feat(scope): description");
 
-    format!(
-        r#"You are a git commit message generator.
+    if req.include_body {
+        format!(
+            r#"You are a git commit message generator.
+Generate a commit message for the following staged changes.
+Use this style: {style}
+
+You MUST use exactly this format with a blank line between subject and body:
+
+feat(scope): short description under 72 chars
+
+This explains WHY the change was made in 2-3 sentences. Focus on
+the reasoning and motivation, not just what changed.
+
+Rules:
+- Subject line: under 72 chars, no period at end
+- Blank line between subject and body (mandatory)
+- Body: explain WHY, not what
+- Output ONLY the commit message, nothing else
+
+Changed files: {files_summary}
+
+Diff:
+{diff_preview}
+
+Commit message (subject, blank line, then body):"#
+        )
+    } else {
+        format!(
+            r#"You are a git commit message generator.
 Generate ONE commit message for the following staged changes.
 Use this style: {style}
 Rules:
@@ -61,47 +99,82 @@ Diff:
 {diff_preview}
 
 Commit message:"#
-    )
+        )
+    }
 }
 
 pub fn generate(req: &GenerateRequest) -> GenerateResponse {
-    let config = crate::config::load();
     let prompt = build_prompt(req);
 
-    match call_ollama(&prompt, &config.ollama_url, &config.model) {
-        Ok(message) => GenerateResponse {
-            message: message.trim().to_string(),
-            confidence: 1.0,
-        },
+    match call_ollama(&prompt) {
+        Ok(raw) => parse_response(raw),
         Err(e) => {
             eprintln!("Model error: {}", e);
             eprintln!("Make sure ollama is running: ollama serve");
             eprintln!("Config file: {}", crate::config::show_path());
             GenerateResponse {
                 message: "chore: update implementation".to_string(),
+                body: None,
                 confidence: 0.0,
             }
         }
     }
 }
 
-fn call_ollama(prompt: &str, base_url: &str, model: &str) -> Result<String, String> {
+fn parse_response(raw: String) -> GenerateResponse {
+    let trimmed = raw.trim().to_string();
+
+    let cleaned = trimmed
+        .trim_end_matches("getBody")
+        .trim_end_matches("getMessage")
+        .trim_end_matches("getSubject")
+        .trim()
+        .to_string();
+
+    let mut parts = cleaned.splitn(3, '\n');
+
+    let subject = parts.next().unwrap_or("").trim().to_string();
+    let second = parts.next().unwrap_or("").trim().to_string();
+    let rest = parts.next().unwrap_or("").trim().to_string();
+
+    let body = if second.is_empty() && !rest.is_empty() {
+        Some(rest)
+    } else if !second.is_empty() {
+        let full_body = if rest.is_empty() {
+            second
+        } else {
+            format!("{}\n{}", second, rest)
+        };
+        Some(full_body)
+    } else {
+        None
+    };
+
+    GenerateResponse {
+        message: subject,
+        body,
+        confidence: 1.0,
+    }
+}
+
+fn call_ollama(prompt: &str) -> Result<String, String> {
+    let config = crate::config::load();
     let client = reqwest::blocking::Client::new();
 
     let body = OllamaRequest {
-        model: model.to_string(),
+        model: config.model.clone(),
         prompt: prompt.to_string(),
         stream: false,
     };
 
-    let url = format!("{}/api/generate", base_url);
+    let url = format!("{}/api/generate", config.ollama_url);
 
     let response = client
         .post(&url)
         .json(&body)
         .timeout(std::time::Duration::from_secs(30))
         .send()
-        .map_err(|e| format!("Failed to reach ollama at {}: {}", base_url, e))?;
+        .map_err(|e| format!("Failed to reach ollama at {}: {}", config.ollama_url, e))?;
 
     let ollama_response: OllamaResponse = response
         .json()


### PR DESCRIPTION
## What this does
Adds --body flag to generate command.
Produces a subject line + reasoning paragraph
explaining WHY the change was made.

## Usage
kommit generate          # subject only (default)
kommit generate --body   # subject + reasoning

## Example output
  Suggested message:

    feat(interactive): update commit generation process

  Reasoning:

    This update modifies the commit generation process
    to include a reasoning body. The reasoning is shown
    through the user interface, allowing additional context
    when committing changes.

## Implementation
- Separate prompt for body mode asking explicitly for WHY
- parse_response splits on blank line separator
- prompt_user shows subject and reasoning separately
- full_message() combines both for git commit

Closes #20